### PR TITLE
Change logic -- first update adds responder, second fulfills request

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -2,6 +2,7 @@ class Request < ActiveRecord::Base
   before_create :defaultly_unfulfilled
 
   has_many :messages
+  has_many :events
 
   belongs_to :requester, class_name: 'User'
   belongs_to :responder, class_name: 'User'


### PR DESCRIPTION
@StevenXL @saraho-shea 
Differentiated between an update to add a responder and to fulfill a request
