### PR TITLE
Changed the order of the before_actions in the UserActions controller.

### DIFF
--- a/app/controllers/user_actions_controller.rb
+++ b/app/controllers/user_actions_controller.rb
@@ -1,6 +1,6 @@
 class UserActionsController < ApplicationController
-  before_action :assigned_to_group
   before_action :logged_in?, only: [:new, :create]
+  before_action :assigned_to_group
 
   private
 


### PR DESCRIPTION
The logged_in? filter should run before the assigned_to_group filter, as
the later needs a user to be logged in to work properly.
