### PR TITLE
Remove the user_id from the migration for Users.

### DIFF
--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -1,7 +1,7 @@
 class Auth0Controller < ApplicationController
   def callback
 
-    user = User.find_or_create_by(user_id: request.env['omniauth.auth']['uid'])
+    user = User.find_or_create_by(user_id: request.env['omniauth.auth']['uid'].to_i)
     user.picture = request.env['omniauth.auth']['info']['image']
     user.first_name = request.env['omniauth.auth']['info']['last_name']
     user.last_name = request.env['omniauth.auth']['info']['first_name']

--- a/db/migrate/20151029211323_create_users.rb
+++ b/db/migrate/20151029211323_create_users.rb
@@ -1,7 +1,6 @@
 class CreateUsers < ActiveRecord::Migration
   def change
   create_table :users do |t|
-      t.string :user_id, null: false
       t.string :first_name, null: false
       t.string :last_name, null: false
       t.string :email, null: false


### PR DESCRIPTION
We don't need to supply this. Let ActiveRecord manage it.
