### PR TITLE
Stevenxl 100 coverage request model (Almost)

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -24,16 +24,11 @@ FactoryGirl.define do
       association :responder
     end
 
-    trait :is_fulfilled do
-      is_fulfilled true
-    end
-
     trait :created_one_day_ago do
       created_at { 1.day.ago }
     end
 
     factory :request_with_neighbor, traits: [:has_neighbor]
-    factory :fulfilled_request , traits: [:has_neighbor, :is_fulfilled]
     factory :day_old_request, traits: [:created_one_day_ago]
   end
 

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -78,6 +78,15 @@ describe Request do
 
     context "request has a neighbor" do
       let(:request) { FactoryGirl.create(:request_with_neighbor) }
+
+      it "should return false if the user is not responder or requester" do
+        expect(request.can_view?(user)).to be false
+      end
+
+      it "should return true if the user is responder or requester" do
+        request = FactoryGirl.create(:request_with_neighbor, requester_id: user.id)
+        expect(request.can_view?(user)).to be true
+      end
     end
   end
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -17,4 +17,67 @@ describe Request do
     it { should belong_to :responder }
     it { should belong_to :group }
   end
+
+  context "#active?" do
+    context "has no responder" do
+      it "should be active if created right now" do
+        expect(FactoryGirl.create(:request).active?).to be true
+      end
+
+      it "should not be active if created more than 45 minutes ago" do
+        expect(FactoryGirl.create(:request, created_at: 1.hour.ago).active?).to be false
+      end
+    end
+
+    context "has a responder" do
+      it "should be active if it is not fulfilled" do
+        expect(FactoryGirl.create(:request_with_neighbor).active?).to be true
+      end
+
+      it "should not be active it is fulfilled" do
+        # NOTE: trait feature in FactoryGirl not working for boolean.
+        request = FactoryGirl.create(:request_with_neighbor)
+        request.is_fulfilled = true
+        request.save
+
+        expect(request.active?).to be false
+      end
+    end
+  end
+
+  context "#is_party_to?" do
+    let(:request) { FactoryGirl.create(:request_with_neighbor) }
+    let(:user)    { FactoryGirl.create(:user)}
+
+    it "should return false when the argument is not a party to the request" do
+      expect(request.is_party_to?(user)).to be false
+    end
+
+    it "should return true when the argument is a party to the request" do
+      request = FactoryGirl.create(:request_with_neighbor, requester_id: user.id)
+      expect(request.is_party_to?(user)).to be true
+    end
+  end
+
+  context "#can_view?" do
+    let(:user)   { FactoryGirl.create(:user) }
+
+    context "request has no neighbor" do
+      let(:request) { FactoryGirl.create(:request) }
+
+      it "should return false if the user is not part of the group" do
+        expect(request.can_view?(user)).to be false
+      end
+
+      it "should return true if the user is part of the group" do
+        user
+        request = FactoryGirl.create(:request, group_id: user.group.id)
+        expect(request.can_view?(user)).to be true
+      end
+    end
+
+    context "request has a neighbor" do
+      let(:request) { FactoryGirl.create(:request_with_neighbor) }
+    end
+  end
 end


### PR DESCRIPTION
We're at 96% test coverage for the Request model. I do not believe the `pretty_date` method should live in the model, but happy to discuss. The `time_ago_in_words` helper is, by default, only available in Views.
