### PR TITLE
Shift group assignment logic to avoid crash

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -19,8 +19,9 @@ class GroupsController < ApplicationController
       flash[:now] = "We couldn't find your building. Can you be more specific?"
       render :inquire
     else
-      flash[:success] = "Welcome to #{user.group.name}"
+      binding.pry
       user.update({group_id: group_id})
+      flash[:success] = "Welcome to #{user.group.name}"
       redirect_to root_path
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
   </head>
 
   <body>
-      <% if current_user %>
+      <% if current_user && current_user.group %>
       <div class="fixed">
         <nav class="top-bar" data-topbar role="navigation">
           <ul class="title-area">


### PR DESCRIPTION
@StevenXL @saraho-shea 
Some logic was calling for group info before it was assigned; shifted logic
