### PR TITLE
Stevenxl fix flash now syntax

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -14,7 +14,7 @@ class MessagesController < UserActionsController
       trigger_message_event(@message)
       redirect_to request_messages_path(@request, anchor: 'bottom')
     else
-      flash[:error] = @message.errors.full_messages.join(', ')
+      flash[:alert] = @message.errors.full_messages.join(', ')
       redirect_to request_messages_path(@request, anchor: 'bottom')
     end
   end
@@ -33,7 +33,7 @@ class MessagesController < UserActionsController
 
   def validate_request_status
     unless (@request.responder && !@request.is_fulfilled)
-      flash[:error] = "This request is no longer active."
+      flash[:alert] = "This request is no longer active."
       redirect_to request_messages_path(@request)
     end
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -14,7 +14,7 @@ class MessagesController < UserActionsController
       trigger_message_event(@message)
       redirect_to request_messages_path(@request, anchor: 'bottom')
     else
-      flash[:now] = @message.errors.full_messages.join(', ')
+      flash.now[:error] = @message.errors.full_messages.join(', ')
       redirect_to request_messages_path(@request, anchor: 'bottom')
     end
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -14,7 +14,7 @@ class MessagesController < UserActionsController
       trigger_message_event(@message)
       redirect_to request_messages_path(@request, anchor: 'bottom')
     else
-      flash.now[:error] = @message.errors.full_messages.join(', ')
+      flash[:error] = @message.errors.full_messages.join(', ')
       redirect_to request_messages_path(@request, anchor: 'bottom')
     end
   end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -19,7 +19,7 @@ class RequestsController < UserActionsController
       end
       redirect_to request_path(@request)
     else
-      flash[:alert] = @request.errors.full_messages.join(", ")
+      flash.now[:alert] = @request.errors.full_messages.join(", ")
       render 'welcome/index'
     end
   end

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -8,7 +8,7 @@ class VotesController < UserActionsController
       flash[:success] = "Thank you for your feedback!"
       redirect_to root_path
     else
-      flash.now[:error] = "Your vote has failed"
+      flash.now[:alert] = "Your vote has failed"
       render 'requests/show.html.erb'
     end
 

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -8,7 +8,7 @@ class VotesController < UserActionsController
       flash[:success] = "Thank you for your feedback!"
       redirect_to root_path
     else
-      flash[:now] = "Your vote has failed"
+      flash.now[:error] = "Your vote has failed"
       render 'requests/show.html.erb'
     end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,6 +48,13 @@
       </div>
     <% end %>
 
+    <% if flash[:success] %>
+      <div data-alert class="alert-box success radius">
+        <%= flash[:alert] %>
+        <a href="#" class="close">&times;</a>
+      </div>
+    <% end %>
+
     <%= yield %>
 
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,6 +40,14 @@
       </li>
       </div></div>
     <% end %>
+
+    <% if flash[:alert] %>
+      <div data-alert class="alert-box alert radius">
+        <%= flash[:alert] %>
+        <a href="#" class="close">&times;</a>
+      </div>
+    <% end %>
+
     <%= yield %>
 
   </body>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -1,5 +1,1 @@
-
-
 <%= render @request %>
-
-

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,10 +1,3 @@
-<% if flash[:alert] %>
-  <div data-alert class="alert-box alert radius">
-    <%= flash[:alert] %>
-    <a href="#" class="close">&times;</a>
-  </div>
-<% end %>
-
 <i class="fi-[torsos-all]"></i>
 <%= render 'requests/new_request_form', request: Request.new %>
 <div class='row collapse sticky top-bar'>

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -61,7 +61,7 @@ describe MessagesController do
       context "invalid message" do
         it "should set a flash error" do
           post :create, { request_id: @request_obj.id, message: { content: '' } }
-          expect(flash[:now]).not_to be_nil
+          expect(flash[:alert]).not_to be_nil
         end
 
         it "should set a flash error" do
@@ -104,7 +104,7 @@ describe MessagesController do
     describe "POST #create" do
       it "should set a flash error" do
         post :create, request_id: @request_obj.id
-        expect(flash[:error]).to be_present
+        expect(flash[:alert]).to be_present
       end
 
       it "should redirect to the request messages" do


### PR DESCRIPTION
We are now using `flash.now` and `flash` properly. Also, the application's layout is now responsible for displaying flash messages. This frees us up from having to duplicate logic across views.
